### PR TITLE
Clean translation files

### DIFF
--- a/static/lang/de.json
+++ b/static/lang/de.json
@@ -76,7 +76,10 @@
       "storyWebAutoArrangeHelp": "Wenn aktiviert, werden Story-Webs neu angeordnet, um ein sauberes Bild zu erhalten. Wenn deaktiviert, können Sie alles genau so positionieren, wie Sie es möchten.",
       "customFields": "Benutzerdefinierte Felder",
       "customFieldsLabel": "Benutzerdefinierte Felder konfigurieren",
-      "customFieldsHelp": "Zusätzliche Felder und KI-Anweisungen für jeden Inhaltstyp konfigurieren"
+      "customFieldsHelp": "Zusätzliche Felder und KI-Anweisungen für jeden Inhaltstyp konfigurieren",
+      "storyWebSettings": "Story Web Settings",
+      "storyWebSettingsLabel": "Configure Settings",
+      "storyWebSettingsHelp": "Configure line colors/styles and element text for story webs"
     },
     "applications": {
       "sessionNotes": {
@@ -294,6 +297,29 @@
       "customFieldsBlocks": {
         "notifications": {
           "saveFailed": "Speichern der benutzerdefinierten Felder fehlgeschlagen"
+        }
+      },
+      "storyWebSettings": {
+        "title": "Configure Story Web Settings",
+        "tabs": {
+          "colors": "Connection Colors",
+          "styles": "Connection Styles",
+          "fields": "Fields"
+        },
+        "columns": {
+          "name": "Name",
+          "color": "Color",
+          "style": "Style",
+          "fieldName": "Field Name",
+          "fieldKey": "Field Key"
+        },
+        "fieldsHint": "The fields in this list will be displayed in the tooltip when hovering over entities in a Story Web.",
+        "contentType": "Content Type",
+        "selectField": "Select Field",
+        "notifications": {
+          "noAvailableFields": "No available fields to add",
+          "duplicateColorIds": "Duplicate color IDs found. Please ensure all color IDs are unique.",
+          "duplicateStyleIds": "Duplicate style IDs found. Please ensure all style IDs are unique."
         }
       }
     },
@@ -824,7 +850,9 @@
         "addDangerWithRelationships": "Gefahr mit Beziehungen hinzufügen",
         "addTextPrompt": "Text eingeben, der dem Diagramm hinzugefügt werden soll",
         "openEntryInNewTab": "Eintrag in neuem Tab öffnen",
-        "openDangerInNewTab": "Gefahr in neuem Tab öffnen"
+        "openDangerInNewTab": "Gefahr in neuem Tab öffnen",
+        "setColor": "Set Color",
+        "setStyle": "Set Style"
       },
       "addToStoryWeb": "Zum aktuellen Story-Web hinzufügen",
       "addWithRelationships": "Mit Beziehungen hinzufügen"

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -76,7 +76,10 @@
       "storyWebAutoArrangeHelp": "Lorsqu'elle est activée, les réseaux d'histoires se réorganiseront pour essayer de garder une image propre. Lorsqu'elle est désactivée, vous pouvez positionner tout exactement comme vous le souhaitez.",
       "customFields": "Champs personnalisés",
       "customFieldsLabel": "Configurer les champs personnalisés",
-      "customFieldsHelp": "Configurer des champs supplémentaires et des instructions AI pour chaque type de contenu"
+      "customFieldsHelp": "Configurer des champs supplémentaires et des instructions AI pour chaque type de contenu",
+      "storyWebSettings": "Story Web Settings",
+      "storyWebSettingsLabel": "Configure Settings",
+      "storyWebSettingsHelp": "Configure line colors/styles and element text for story webs"
     },
     "applications": {
       "sessionNotes": {
@@ -294,6 +297,29 @@
       "customFieldsBlocks": {
         "notifications": {
           "saveFailed": "Échec de l'enregistrement des champs personnalisés"
+        }
+      },
+      "storyWebSettings": {
+        "title": "Configure Story Web Settings",
+        "tabs": {
+          "colors": "Connection Colors",
+          "styles": "Connection Styles",
+          "fields": "Fields"
+        },
+        "columns": {
+          "name": "Name",
+          "color": "Color",
+          "style": "Style",
+          "fieldName": "Field Name",
+          "fieldKey": "Field Key"
+        },
+        "fieldsHint": "The fields in this list will be displayed in the tooltip when hovering over entities in a Story Web.",
+        "contentType": "Content Type",
+        "selectField": "Select Field",
+        "notifications": {
+          "noAvailableFields": "No available fields to add",
+          "duplicateColorIds": "Duplicate color IDs found. Please ensure all color IDs are unique.",
+          "duplicateStyleIds": "Duplicate style IDs found. Please ensure all style IDs are unique."
         }
       }
     },
@@ -824,7 +850,9 @@
         "addDangerWithRelationships": "Ajouter un danger avec des relations",
         "addTextPrompt": "Entrer le texte à ajouter au diagramme",
         "openEntryInNewTab": "Ouvrir l'entrée dans un nouvel onglet",
-        "openDangerInNewTab": "Ouvrir le danger dans un nouvel onglet"
+        "openDangerInNewTab": "Ouvrir le danger dans un nouvel onglet",
+        "setColor": "Set Color",
+        "setStyle": "Set Style"
       },
       "addToStoryWeb": "Ajouter à l'histoire Web actuelle",
       "addWithRelationships": "Ajouter avec les relations"

--- a/static/lang/ru.json
+++ b/static/lang/ru.json
@@ -76,7 +76,10 @@
       "storyWebAutoArrangeHelp": "Когда включено, сети историй будут перестраиваться, чтобы попытаться сохранить чистую картину. Когда отключено, вы можете расположить все так, как вам нужно.",
       "customFields": "Пользовательские поля",
       "customFieldsLabel": "Настроить пользовательские поля",
-      "customFieldsHelp": "Настройте дополнительные поля и инструкции ИИ для каждого типа контента"
+      "customFieldsHelp": "Настройте дополнительные поля и инструкции ИИ для каждого типа контента",
+      "storyWebSettings": "Story Web Settings",
+      "storyWebSettingsLabel": "Configure Settings",
+      "storyWebSettingsHelp": "Configure line colors/styles and element text for story webs"
     },
     "applications": {
       "sessionNotes": {
@@ -294,6 +297,29 @@
       "customFieldsBlocks": {
         "notifications": {
           "saveFailed": "Не удалось сохранить пользовательские поля"
+        }
+      },
+      "storyWebSettings": {
+        "title": "Configure Story Web Settings",
+        "tabs": {
+          "colors": "Connection Colors",
+          "styles": "Connection Styles",
+          "fields": "Fields"
+        },
+        "columns": {
+          "name": "Name",
+          "color": "Color",
+          "style": "Style",
+          "fieldName": "Field Name",
+          "fieldKey": "Field Key"
+        },
+        "fieldsHint": "The fields in this list will be displayed in the tooltip when hovering over entities in a Story Web.",
+        "contentType": "Content Type",
+        "selectField": "Select Field",
+        "notifications": {
+          "noAvailableFields": "No available fields to add",
+          "duplicateColorIds": "Duplicate color IDs found. Please ensure all color IDs are unique.",
+          "duplicateStyleIds": "Duplicate style IDs found. Please ensure all style IDs are unique."
         }
       }
     },
@@ -845,7 +871,9 @@
         "addDangerWithRelationships": "Добавить опасность со связями",
         "addTextPrompt": "Введите текст для добавления на диаграмму",
         "openEntryInNewTab": "Открыть запись в новой вкладке",
-        "openDangerInNewTab": "Открыть опасность в новой вкладке"
+        "openDangerInNewTab": "Открыть опасность в новой вкладке",
+        "setColor": "Set Color",
+        "setStyle": "Set Style"
       },
       "addToStoryWeb": "Добавить в текущую Story Web",
       "addWithRelationships": "Добавить с отношениями"


### PR DESCRIPTION
Clean translation files for branch `colored-lines`

This PR:
- Adds missing translation keys to match the English source
- Removes unused keys that no longer exist in the English source
- Preserves existing translations without retranslating

Languages processed: all